### PR TITLE
Handle fractional-sized pages "correctly" as floats.

### DIFF
--- a/pdf_info.py
+++ b/pdf_info.py
@@ -52,7 +52,7 @@ def get_mediaboxes(pdf: Pdf):
     if rotate == 90 or rotate == 270:
       width, height = height, width
 
-    mediaboxes.append((width, height))
+    mediaboxes.append((float(width), float(height)))
   return mediaboxes
 
 

--- a/third_party/hocr_tools/hocr_pdf.py
+++ b/third_party/hocr_tools/hocr_pdf.py
@@ -59,6 +59,9 @@ async def export_pdf(document, mediaboxes, title, output_file):
     for text_page, page in zip(text_pdf.pages, document.pages):
       await asyncio.sleep(0)
       _, _, width, height = text_page.trimbox
+      width = float(width)
+      height = float(height)
+
       layout_fun = img2pdf.get_layout_fun((width, height))
       bg_buf = io.BytesIO()
       img2pdf.convert(page.image.content, layout_fun=layout_fun,


### PR DESCRIPTION
Both ReportLab and img2pdf expect floats, rather than `decimal.Decimal`,
so there's no value to passing Decimal out from pdf_info in practice.
Fixes #1.