### PR TITLE
pdf_sprinkles: make `pdf_info` timeout configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ These flags can be set for both the CLI and Web frontends.
 * `--processor_id`: ID of document processor
 * `--project_id`: Google Cloud project ID
 
+`pdf_sprinkles`:
+
+* `--pdf_info_timeout`: Timeout in seconds for pdf_info.
+    (default: 1)
+
 `third_party.hocr_tools.hocr_pdf`:
 
 * `--min_confidence`: Minimum confidence of lines to include in output.

--- a/pdf_sprinkles.py
+++ b/pdf_sprinkles.py
@@ -23,11 +23,15 @@ import subprocess
 import sys
 from typing import BinaryIO
 
+from absl import flags
 from absl import logging
 import document_ai_ocr
 from google.cloud import documentai_v1 as documentai
 from third_party.hocr_tools import hocr_pdf
 import tornado.process
+
+FLAGS = flags.FLAGS
+flags.DEFINE_integer('pdf_info_timeout', 1, 'Timeout in seconds for pdf_info.')
 
 
 async def convert(input_file: BinaryIO, input_file_name: str,
@@ -46,7 +50,8 @@ async def convert(input_file: BinaryIO, input_file_name: str,
       stdout=tornado.process.Subprocess.STREAM,
       stderr=subprocess.DEVNULL)
   pdf_info_reader = pdf_info.stdout.read_bytes(4 * 1024, partial=True)
-  pdf_info_waiter = asyncio.wait_for(pdf_info.wait_for_exit(), timeout=1)
+  pdf_info_waiter = asyncio.wait_for(
+      pdf_info.wait_for_exit(), timeout=FLAGS.pdf_info_timeout)
 
   try:
     for coro in asyncio.as_completed(

--- a/pdf_sprinkles.py
+++ b/pdf_sprinkles.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """pdf_sprinkles: sprinkles text in your PDFs.
 
 More seriously, it converts an PDF to a searchable PDF using Google Cloud
@@ -31,8 +30,8 @@ from third_party.hocr_tools import hocr_pdf
 import tornado.process
 
 
-async def convert(
-    input_file: BinaryIO, input_file_name: str, output_file: BinaryIO):
+async def convert(input_file: BinaryIO, input_file_name: str,
+                  output_file: BinaryIO):
   """Converts an image-only PDF into a PDF with OCR text."""
   recognizer = document_ai_ocr.recognize(input_file)
 
@@ -43,7 +42,8 @@ async def convert(
   # available in the App Engine runtime. So we limit reads with asyncio instead.
   pdf_info = tornado.process.Subprocess(
       [sys.executable, '-m', 'pdf_info'],
-      stdin=input_file, stdout=tornado.process.Subprocess.STREAM,
+      stdin=input_file,
+      stdout=tornado.process.Subprocess.STREAM,
       stderr=subprocess.DEVNULL)
   pdf_info_reader = pdf_info.stdout.read_bytes(4 * 1024, partial=True)
   pdf_info_waiter = asyncio.wait_for(pdf_info.wait_for_exit(), timeout=1)


### PR DESCRIPTION
This is helpful running inside a VM, where things may take longer.