### PR TITLE
Make PDF Sprinkles portable to Google's monorepo

### DIFF
--- a/pdf_sprinkles/app_context.py
+++ b/pdf_sprinkles/app_context.py
@@ -56,7 +56,7 @@ def set_request_data(request: tornado.httputil.HTTPServerRequest):
   http_request.set({
       'requestMethod': request.method,
       'requestUrl': request.uri,
-      'requestSize': len(request.body),
+      'requestSize': len(request.body) if isinstance(request.body, str) else 0,
       'userAgent': request.headers.get('User-Agent', ''),
       'remoteIp': request.remote_ip,
       'referer': request.headers.get('Referer', ''),

--- a/pdf_sprinkles/convert.py
+++ b/pdf_sprinkles/convert.py
@@ -31,6 +31,10 @@ from third_party.hocr_tools import hocr_pdf
 import tornado.process
 
 FLAGS = flags.FLAGS
+flags.DEFINE_multi_string(
+    'pdf_info_command',
+    [sys.executable, '-m', 'pdf_sprinkles.pdf_info'] if sys.executable else [],
+    'Command to run pdf_info.')
 flags.DEFINE_integer('pdf_info_timeout', 1, 'Timeout in seconds for pdf_info.')
 
 
@@ -45,7 +49,7 @@ async def convert(input_file: BinaryIO, input_file_name: str,
   # Normally you'd use `head` in a pipeline to limit reads, but it's not
   # available in the App Engine runtime. So we limit reads with asyncio instead.
   pdf_info = tornado.process.Subprocess(
-      [sys.executable, '-m', 'pdf_sprinkles.pdf_info'],
+      FLAGS.pdf_info_command,
       stdin=input_file,
       stdout=tornado.process.Subprocess.STREAM,
       stderr=subprocess.DEVNULL)

--- a/pdf_sprinkles/convert.py
+++ b/pdf_sprinkles/convert.py
@@ -24,11 +24,9 @@ import sys
 from typing import BinaryIO
 
 from absl import flags
-from absl import logging
-from google.cloud import documentai_v1 as documentai
 from pdf_sprinkles import document_ai_ocr
 from third_party.hocr_tools import hocr_pdf
-import tornado.process
+
 
 FLAGS = flags.FLAGS
 flags.DEFINE_multi_string(
@@ -41,42 +39,21 @@ flags.DEFINE_integer('pdf_info_timeout', 1, 'Timeout in seconds for pdf_info.')
 async def convert(input_file: BinaryIO, input_file_name: str,
                   output_file: BinaryIO):
   """Converts an image-only PDF into a PDF with OCR text."""
-  recognizer = document_ai_ocr.recognize(input_file)
+  document = await document_ai_ocr.recognize(input_file)
 
-  # Read mediaboxes from PDFs in a sandbox. Limit how much we'll read from the
-  # sandbox, and how long we'll let it run.
-  #
-  # Normally you'd use `head` in a pipeline to limit reads, but it's not
-  # available in the App Engine runtime. So we limit reads with asyncio instead.
-  pdf_info = tornado.process.Subprocess(
-      FLAGS.pdf_info_command,
+  # Read mediaboxes from PDFs in a sandbox, limiting how long we'll let it run.
+  pdf_info = await asyncio.create_subprocess_exec(
+      *FLAGS.pdf_info_command,
       stdin=input_file,
-      stdout=tornado.process.Subprocess.STREAM,
+      stdout=asyncio.subprocess.PIPE,
       stderr=subprocess.DEVNULL)
-  pdf_info_reader = pdf_info.stdout.read_bytes(4 * 1024, partial=True)
-  pdf_info_waiter = asyncio.wait_for(
-      pdf_info.wait_for_exit(), timeout=FLAGS.pdf_info_timeout)
-
   try:
-    for coro in asyncio.as_completed(
-        [recognizer, pdf_info_reader, pdf_info_waiter]):
-      result = await coro
-
-      # coro might not equal a coroutine passed to asyncio.as_completed,
-      # so dispatch on result types instead
-      if isinstance(result, int):  # pdf_info return code
-        logging.debug('convert.pdf_info_waiter: %d', result)
-      elif isinstance(result, bytes):  # pdf_info stdout
-        logging.debug('convert.pdf_info_reader: %d bytes', len(result))
-        mediaboxes_buf = result
-        pdf_info.stdout.close()  # close the pipe like `head` does.
-      elif isinstance(result, documentai.Document):  # Document AI result
-        logging.debug('convert.recognizer')
-        document = result
+    pdf_info_result = await asyncio.wait_for(
+        pdf_info.communicate(), timeout=FLAGS.pdf_info_timeout)
 
     # Loading mediaboxes after all coroutines finish ensures we've waited for
     # pdf_info to return. This provides cleaner logs if JSON decode fails.
-    mediaboxes = json.loads(mediaboxes_buf)
+    mediaboxes = json.loads(pdf_info_result[0])
 
   # Re-raise exceptions that happen when reading a bad PDF locally with a
   # more user-friendly (and less hacker-friendly) error message.
@@ -84,15 +61,5 @@ async def convert(input_file: BinaryIO, input_file_name: str,
           ValueError) as exc:
     raise ValueError("Couldn't read uploaded PDF.") from exc
   # We let gRPC errors reach the user unchanged.
-  finally:
-    # in case of exception:
-    # - the pipe from pdf_info may still be open, and
-    # - the pdf_info process may still be running.
-    #
-    # close the pipe and kill the process to prevent leaks.
-    if not pdf_info.stdout.closed():
-      pdf_info.stdout.close()
-    if pdf_info.proc.poll() is None:
-      pdf_info.proc.kill()
 
   await hocr_pdf.export_pdf(document, mediaboxes, input_file_name, output_file)

--- a/pdf_sprinkles/convert.py
+++ b/pdf_sprinkles/convert.py
@@ -25,14 +25,12 @@ from typing import BinaryIO
 
 from absl import flags
 from pdf_sprinkles import document_ai_ocr
+from pdf_sprinkles import resources
 from third_party.hocr_tools import hocr_pdf
 
 
 FLAGS = flags.FLAGS
-flags.DEFINE_multi_string(
-    'pdf_info_command',
-    [sys.executable, '-m', 'pdf_sprinkles.pdf_info'] if sys.executable else [],
-    'Command to run pdf_info.')
+flags.DEFINE_string('pdf_info_command', '', 'Command to run pdf_info.')
 flags.DEFINE_integer('pdf_info_timeout', 1, 'Timeout in seconds for pdf_info.')
 
 
@@ -41,9 +39,14 @@ async def convert(input_file: BinaryIO, input_file_name: str,
   """Converts an image-only PDF into a PDF with OCR text."""
   document = await document_ai_ocr.recognize(input_file)
 
+  if FLAGS.pdf_info_command:
+    pdf_info_command = [resources.GetResourceFilename(FLAGS.pdf_info_command)]
+  else:
+    pdf_info_command = [sys.executable, '-m', 'pdf_sprinkles.pdf_info']
+
   # Read mediaboxes from PDFs in a sandbox, limiting how long we'll let it run.
   pdf_info = await asyncio.create_subprocess_exec(
-      *FLAGS.pdf_info_command,
+      *pdf_info_command,
       stdin=input_file,
       stdout=asyncio.subprocess.PIPE,
       stderr=subprocess.DEVNULL)

--- a/pdf_sprinkles/iap_auth.py
+++ b/pdf_sprinkles/iap_auth.py
@@ -15,7 +15,6 @@
 
 import json
 
-from absl import flags
 from google.auth import jwt
 from tornado.httpclient import AsyncHTTPClient
 
@@ -23,15 +22,15 @@ from tornado.httpclient import AsyncHTTPClient
 async def validate_iap_jwt(iap_jwt, expected_audience):
   """Validate an IAP JWT.
 
-    Args:
-      iap_jwt: The contents of the X-Goog-IAP-JWT-Assertion header.
-      expected_audience: The Signed Header JWT audience. See
-          https://cloud.google.com/iap/docs/signed-headers-howto
-          for details on how to get this value.
+  Args:
+    iap_jwt: The contents of the X-Goog-IAP-JWT-Assertion header.
+    expected_audience: The Signed Header JWT audience. See
+        https://cloud.google.com/iap/docs/signed-headers-howto
+        for details on how to get this value.
 
-    Returns:
-      (user_id, user_email).
-    """
+  Returns:
+    (user_id, user_email).
+  """
 
   http_client = AsyncHTTPClient()
   response = await http_client.fetch(

--- a/pdf_sprinkles/resources.py
+++ b/pdf_sprinkles/resources.py
@@ -1,0 +1,5 @@
+"""Stub module for resource filenames."""
+
+
+def GetResourceFilename(name, unused_mode='rb'):
+  return name

--- a/pdf_sprinkles_cli.py
+++ b/pdf_sprinkles_cli.py
@@ -24,6 +24,7 @@ from typing import Sequence
 from absl import app
 from absl import flags
 from pdf_sprinkles.convert import convert
+from tornado.platform.asyncio import AsyncIOMainLoop
 
 
 FLAGS = flags.FLAGS
@@ -34,6 +35,8 @@ flags.DEFINE_string('output', None, 'Path to output file')
 def main(argv: Sequence[str]) -> None:
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
+
+  AsyncIOMainLoop().install()
 
   with open(FLAGS.input, 'rb') as input_file, open(
       FLAGS.output, 'wb') if FLAGS.output else open(

--- a/pdf_sprinkles_web.py
+++ b/pdf_sprinkles_web.py
@@ -37,6 +37,7 @@ from pdf_sprinkles.convert import convert
 from third_party.hocr_tools import hocr_pdf
 import tornado.httpserver
 import tornado.ioloop
+from tornado.platform.asyncio import AsyncIOMainLoop
 import tornado.web
 
 FLAGS = flags.FLAGS
@@ -127,6 +128,8 @@ class StaticFileHandler(tornado.web.StaticFileHandler,
 def main(argv: Sequence[str]) -> None:
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
+
+  AsyncIOMainLoop().install()
 
   if FLAGS.cloud_logging:
     cloud_logging_client = google.cloud.logging.Client()

--- a/pdf_sprinkles_web.py
+++ b/pdf_sprinkles_web.py
@@ -162,7 +162,8 @@ def main(argv: Sequence[str]) -> None:
           base64.b64decode(response.payload.data))
 
     if not cookie_secrets:
-      logging.fatal('No enabled versions found for secret %s', secret_path)
+      raise app.UsageError(
+          f'No enabled versions found for secret {secret_path}')
 
     settings.update({
         'cookie_secret': cookie_secrets,

--- a/third_party/hocr_tools/hocr_pdf.py
+++ b/third_party/hocr_tools/hocr_pdf.py
@@ -26,6 +26,7 @@ from absl import logging
 from bidi.algorithm import get_display
 from google.cloud import documentai_v1 as documentai
 import img2pdf
+from pdf_sprinkles import resources
 from pikepdf import Pdf
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
@@ -33,6 +34,9 @@ from reportlab.pdfgen.canvas import Canvas
 
 
 FLAGS = flags.FLAGS
+flags.DEFINE_multi_string(
+    'font', ['Noto Sans', 'third_party/noto-fonts/NotoSans-Regular.ttf'],
+    'Font to include in input.')
 flags.DEFINE_float('min_confidence', 0.9, 'Minimum confidence of lines to '
                    'include in output.')
 
@@ -158,5 +162,6 @@ def load_noto_sans():
   global _fonts_loaded
   if not _fonts_loaded:
     _fonts_loaded = True
-    pdfmetrics.registerFont(TTFont(
-        'Noto Sans', 'third_party/noto-fonts/NotoSans-Regular.ttf'))
+
+    font, path = FLAGS.font
+    pdfmetrics.registerFont(TTFont(font, resources.GetResourceFilename(path)))


### PR DESCRIPTION
* Support hermetic Python interpreters
* Relax sandboxing slightly to account for interpreter differences
* Work with dependencies at monorepo's LTS versions